### PR TITLE
Fix build process and restore npm scripts

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+
+const projectRoot = __dirname;
+const distDir = path.join(projectRoot, 'dist');
+
+fs.rmSync(distDir, { recursive: true, force: true });
+fs.mkdirSync(distDir, { recursive: true });
+
+// copy public files
+fs.cpSync(path.join(projectRoot, 'public'), distDir, { recursive: true });
+// copy src directory
+fs.cpSync(path.join(projectRoot, 'src'), path.join(distDir, 'src'), { recursive: true });
+
+// update index.html paths
+const indexPath = path.join(distDir, 'index.html');
+let html = fs.readFileSync(indexPath, 'utf8');
+html = html.replace(/\.\.\/src\//g, 'src/');
+fs.writeFileSync(indexPath, html);
+
+console.log('Build complete. Files copied to dist/');

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "StampExpert static site",
   "scripts": {
+    "start": "npx live-server --entry-file=public/index.html .",
+    "build": "node build.js",
+    "server": "node server.js"
   },
   "devDependencies": {
     "live-server": "^1.2.1"


### PR DESCRIPTION
## Summary
- restore `start`, `build` and `server` npm scripts
- add `build.js` script to copy files and rewrite paths for production

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ebab66140832ca1511f9b9abf8933