### PR TITLE
Update README start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,13 @@ Identify and catalog stamps from around the world with our advanced recognition 
 Run `npm install` to install development dependencies.
 
 ## Development
-Start a local development server that serves the files in `public/` with:
+Start the application server from the project root with:
 
 ```bash
-npm run start
+npm start
 ```
 
-The command runs `live-server` against the `public/` folder. Once it starts you
-can open [http://localhost:8080](http://localhost:8080) (or the URL shown in the
-terminal) in your browser to use the app.
-
-You can also run the Node.js API server which serves the same static files and exposes a stub `/api/analyze` endpoint:
-
-```bash
-npm run server
-```
+The command executes `server.js`, which serves the content in the `public/` folder and exposes a stub `/api/analyze` endpoint. Once it starts you can open [http://localhost:3000](http://localhost:3000) (or the URL shown in the terminal) in your browser to use the app.
 
 ## Build
 Create a production build in the `dist/` directory with:


### PR DESCRIPTION
## Summary
- explain running the server from the project root with `npm start`
- clarify how to access the app

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686ebabd89fc832c99db425fa01f5794