### PR TITLE
Add environment variable config docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -19,3 +19,28 @@ Create a production build in the `dist/` directory with:
 ```bash
 npm run build
 ```
+
+## Configuration
+
+The server can be configured via environment variables:
+
+| Variable | Description | Default |
+| -------- | ----------- | ------- |
+| `PORT`   | Port that the HTTP server listens on | `3000` |
+
+Set these variables before starting the application if you need to override the defaults.
+
+## Production Deployment
+
+For a simple deployment run the server directly with Node:
+
+```bash
+NODE_ENV=production PORT=8080 node server.js
+```
+
+You can also build a Docker image using the provided `Dockerfile`:
+
+```bash
+docker build -t stampexpert .
+docker run -p 8080:8080 -e PORT=8080 stampexpert
+```

--- a/server.js
+++ b/server.js
@@ -1,6 +1,9 @@
 const express = require('express');
 const path = require('path');
 
+// Configuration via environment variables:
+//   PORT - port number for the HTTP server (defaults to 3000)
+
 const app = express();
 const PORT = process.env.PORT || 3000;
 


### PR DESCRIPTION
## Summary
- explain PORT configuration in `server.js`
- document PORT and production deployment steps in README
- add Dockerfile for containerized deployments

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687034e5d720832c9fcaa83b44bfbfd7