### PR TITLE
Expose src with Express and update build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "StampExpert static site",
   "scripts": {
     "start": "node server.js",
-    "build": "rm -rf dist && mkdir dist && cp -r public/* dist/ && cp -r src dist/",
+    "build": "node build.js",
     "test": "jest --runInBand"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 
 app.use(express.static(path.join(__dirname, 'public')));
+app.use('/src', express.static(path.join(__dirname, 'src')));
 app.use(express.json());
 
 app.post('/api/analyze', (req, res) => {


### PR DESCRIPTION
## Summary
- serve the `src` folder statically under `/src`
- change build script to run `node build.js`

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687042f19968832cbc6a9f3b46416457